### PR TITLE
PowerUp command added

### DIFF
--- a/SysBot.Pokemon.Discord/Commands/Bots/CloneModule.cs
+++ b/SysBot.Pokemon.Discord/Commands/Bots/CloneModule.cs
@@ -52,6 +52,17 @@ namespace SysBot.Pokemon.Discord
             await Context.AddToQueueAsync(code, Context.User.Username, sig, new PK8(), PokeRoutineType.FixOT, PokeTradeType.FixOT).ConfigureAwait(false);
         }
 
+        [Command("powerUp")]
+        [Alias("pu")]
+        [Summary("Maxes out EXP, dynamax level, and PP ups of a Pokémon you show via Link Trade, teaches all compatible TRs, enables gigantamax if available, and hyper trains all non min/maxed IVs.")]
+        [RequireQueueRole(nameof(DiscordManager.RolesPowerUp))]
+        public async Task PowerUp()
+        {
+            var code = Info.GetRandomTradeCode();
+            var sig = Context.User.GetFavor();
+            await Context.AddToQueueAsync(code, Context.User.Username, sig, new PK8(), PokeRoutineType.PowerUp, PokeTradeType.PowerUp).ConfigureAwait(false);
+        }
+
         [Command("cloneList")]
         [Alias("cl", "cq")]
         [Summary("Prints the users in the Clone queue.")]
@@ -76,6 +87,23 @@ namespace SysBot.Pokemon.Discord
         public async Task GetFixListAsync()
         {
             string msg = Info.GetTradeList(PokeRoutineType.FixOT);
+            var embed = new EmbedBuilder();
+            embed.AddField(x =>
+            {
+                x.Name = "Pending Trades";
+                x.Value = msg;
+                x.IsInline = false;
+            });
+            await ReplyAsync("These are the users who are currently waiting:", embed: embed.Build()).ConfigureAwait(false);
+        }
+
+        [Command("powerUpList")]
+        [Alias("pl", "pq")]
+        [Summary("Prints the users in the PowerUp queue.")]
+        [RequireSudo]
+        public async Task GetFixListAsync()
+        {
+            string msg = Info.GetTradeList(PokeRoutineType.PowerUp);
             var embed = new EmbedBuilder();
             embed.AddField(x =>
             {

--- a/SysBot.Pokemon.Discord/Helpers/DiscordManager.cs
+++ b/SysBot.Pokemon.Discord/Helpers/DiscordManager.cs
@@ -18,6 +18,7 @@ namespace SysBot.Pokemon.Discord
 
         public readonly SensitiveSet<string> RolesClone = new SensitiveSet<string>();
         public readonly SensitiveSet<string> RolesFixOT = new SensitiveSet<string>();
+        public readonly SensitiveSet<string> RolesPowerUp = new SensitiveSet<string>();
         public readonly SensitiveSet<string> RolesEggRoll = new SensitiveSet<string>();
         public readonly SensitiveSet<string> RolesTrade = new SensitiveSet<string>();
         public readonly SensitiveSet<string> RolesSeed = new SensitiveSet<string>();
@@ -61,6 +62,7 @@ namespace SysBot.Pokemon.Discord
             {
                 nameof(RolesClone) => RolesClone,
                 nameof(RolesFixOT) => RolesFixOT,
+                nameof(RolesPowerUp) => RolesPowerUp,
                 nameof(RolesEggRoll) => RolesEggRoll,
                 nameof(RolesTrade) => RolesTrade,
                 nameof(RolesSeed) => RolesSeed,
@@ -82,6 +84,7 @@ namespace SysBot.Pokemon.Discord
 
             RolesClone.Read(cfg.Discord.RoleCanClone, z => z);
             RolesFixOT.Read(cfg.Discord.RoleCanFixOT, z => z);
+            RolesPowerUp.Read(cfg.Discord.RoleCanPowerUp, z => z);
             RolesEggRoll.Read(cfg.Discord.RoleCanEggRoll, z => z);
             RolesTrade.Read(cfg.Discord.RoleCanTrade, z => z);
             RolesSeed.Read(cfg.Discord.RoleCanSeedCheck, z => z);
@@ -99,6 +102,7 @@ namespace SysBot.Pokemon.Discord
 
             Config.Discord.RoleCanClone = RolesClone.Write();
             Config.Discord.RoleCanFixOT = RolesFixOT.Write();
+            Config.Discord.RoleCanPowerUp = RolesPowerUp.Write();
             Config.Discord.RoleCanEggRoll = RolesEggRoll.Write();
             Config.Discord.RoleCanTrade = RolesTrade.Write();
             Config.Discord.RoleCanSeedCheck = RolesSeed.Write();

--- a/SysBot.Pokemon/Actions/PokeRoutineType.cs
+++ b/SysBot.Pokemon/Actions/PokeRoutineType.cs
@@ -11,6 +11,7 @@
         SeedCheck,
         Clone,
         FixOT,
+        PowerUp,
         EggRoll,
         Dump,
 

--- a/SysBot.Pokemon/BotTrade/BotCompleteCounts.cs
+++ b/SysBot.Pokemon/BotTrade/BotCompleteCounts.cs
@@ -18,6 +18,7 @@ namespace SysBot.Pokemon
         private int CompletedDistribution;
         private int CompletedClones;
         private int CompletedFixOTs;
+        private int CompletedPowerUps;
         private int CompletedEggRolls;
         private int CompletedDumps;
         private int CompletedRaids;
@@ -40,6 +41,7 @@ namespace SysBot.Pokemon
             CompletedDistribution = Config.CompletedDistribution;
             CompletedClones = Config.CompletedClones;
             CompletedFixOTs = Config.CompletedFixOTs;
+            CompletedPowerUps = Config.CompletedPowerUps;
             CompletedEggRolls = Config.CompletedEggRolls;
             CompletedDumps = Config.CompletedDumps;
             CompletedRaids = Config.CompletedRaids;
@@ -105,6 +107,12 @@ namespace SysBot.Pokemon
             Config.CompletedFixOTs = CompletedFixOTs;
         }
 
+        public void AddCompletedPowerUps()
+        {
+            Interlocked.Increment(ref CompletedPowerUps);
+            Config.CompletedPowerUps = CompletedPowerUps;
+        }
+
         public void AddCompletedEggRolls()
         {
             Interlocked.Increment(ref CompletedEggRolls);
@@ -131,6 +139,8 @@ namespace SysBot.Pokemon
                 yield return $"Clone Trades: {CompletedClones}";
             if (CompletedFixOTs != 0)
                 yield return $"FixOT Trades: {CompletedFixOTs}";
+            if (CompletedPowerUps != 0)
+                yield return $"PowerUp Trades: {CompletedPowerUps}";
             if (CompletedEggRolls != 0)
                 yield return $"EggRoll Trades: {CompletedEggRolls}";
             if (CompletedDumps != 0)
@@ -236,11 +246,11 @@ namespace SysBot.Pokemon
 
             var totalSpecies = System.Text.RegularExpressions.Regex.Matches(content, countSpecies, System.Text.RegularExpressions.RegexOptions.Multiline).OfType<System.Text.RegularExpressions.Match>().Select(countSpecies => int.Parse(countSpecies.Groups[1].Value)).Sum();
             var totalShiny = System.Text.RegularExpressions.Regex.Matches(content, countShiny, System.Text.RegularExpressions.RegexOptions.Multiline).OfType<System.Text.RegularExpressions.Match>().Select(countShiny => int.Parse(countShiny.Groups[1].Value)).Sum();
-            
+
             if (pkm.IsEgg)
                 content = System.Text.RegularExpressions.Regex.Replace(content, total, $"Total = {totalSpecies} Eggs, {totalShiny} Shiny", System.Text.RegularExpressions.RegexOptions.Multiline).TrimEnd();
             else content = System.Text.RegularExpressions.Regex.Replace(content, total, $"Total = {totalSpecies} Pokémon, {totalShiny} Shiny", System.Text.RegularExpressions.RegexOptions.Multiline).TrimEnd();
-            
+
             System.IO.StreamWriter writer = new System.IO.StreamWriter(file);
             writer.WriteLine(content);
             writer.Close();

--- a/SysBot.Pokemon/BotTrade/PokeTradeBot.cs
+++ b/SysBot.Pokemon/BotTrade/PokeTradeBot.cs
@@ -335,6 +335,49 @@ namespace SysBot.Pokemon
                 for (int i = 0; i < 5; i++)
                     await Click(A, 0_500, token).ConfigureAwait(false);
             }
+            else if (poke.Type == PokeTradeType.PowerUp)
+            {
+                var clone = (PK8)pk.Clone();
+
+                clone.SetRecordFlags();
+                clone.MaximizeLevel();
+                clone.SetMaximumPPUps();
+                clone.SetSuggestedHyperTrainingData(clone.IVs);
+                if (clone is IGigantamax c)
+                    c.CanGigantamax = true;
+                if (clone is IDynamaxLevel d)
+                    d.DynamaxLevel = (byte)(d.CanHaveDynamaxLevel(clone) ? 10 : 0);
+
+                var la = new LegalityAnalysis(clone);
+                if (!la.Valid && Hub.Config.Legality.VerifyLegality)
+                {
+                    Log($"PowerUp request has detected an invalid Pokémon: {(Species)clone.Species}");
+                    if (DumpSetting.Dump)
+                        DumpPokemon(DumpSetting.DumpFolder, "hacked", clone);
+
+                    var report = la.Report();
+                    Log(report);
+                    poke.SendNotification(this, "This Pokémon is not legal per PKHeX's legality checks. I am forbidden from modifying this. Exiting trade.");
+                    poke.SendNotification(this, report);
+
+                    await ExitTrade(Hub.Config, true, token).ConfigureAwait(false);
+                    return PokeTradeResult.IllegalTrade;
+                }
+
+                if (Hub.Config.Legality.ResetHOMETracker)
+                    clone.Tracker = 0;
+
+                poke.SendNotification(this, $"```pu\nPowered up your {(Species)clone.Species}! Now confirm the trade!```");
+                Log($"Powered up {(Species)clone.Species}.");
+
+                await ReadUntilPresent(LinkTradePartnerPokemonOffset, 3_000, 1_000, token).ConfigureAwait(false);
+                await Click(A, 0_800, token).ConfigureAwait(false);
+                await SetBoxPokemon(clone, InjectBox, InjectSlot, token, sav).ConfigureAwait(false);
+                pkm = clone;
+
+                for (int i = 0; i < 5; i++)
+                    await Click(A, 0_500, token).ConfigureAwait(false);
+            }
             else if (poke.Type == PokeTradeType.Clone)
             {
                 // Inject the shown Pokémon.
@@ -417,7 +460,7 @@ namespace SysBot.Pokemon
             // Trade was Successful!
             var traded = await ReadBoxPokemon(InjectBox, InjectSlot, token).ConfigureAwait(false);
             // Pokémon in b1s1 is same as the one they were supposed to receive (was never sent).
-            if (poke.Type != PokeTradeType.FixOT && SearchUtil.HashByDetails(traded) == SearchUtil.HashByDetails(pkm))
+            if (poke.Type != PokeTradeType.FixOT && poke.Type != PokeTradeType.PowerUp && SearchUtil.HashByDetails(traded) == SearchUtil.HashByDetails(pkm))
             {
                 Log("User did not complete the trade.");
                 return PokeTradeResult.TrainerTooSlow;
@@ -436,6 +479,8 @@ namespace SysBot.Pokemon
                     counts.AddCompletedClones();
                 else if (poke.Type == PokeTradeType.FixOT)
                     counts.AddCompletedFixOTs();
+                else if (poke.Type == PokeTradeType.PowerUp)
+                    counts.AddCompletedPowerUps();
                 else if (poke.Type == PokeTradeType.EggRoll)
                     counts.AddCompletedEggRolls();
                 else
@@ -445,7 +490,7 @@ namespace SysBot.Pokemon
                 {
                     var subfolder = poke.Type.ToString().ToLower();
                     DumpPokemon(DumpSetting.DumpFolder, subfolder, traded); // received
-                    if (poke.Type == PokeTradeType.Specific || poke.Type == PokeTradeType.Clone || poke.Type == PokeTradeType.FixOT || poke.Type == PokeTradeType.EggRoll)
+                    if (poke.Type == PokeTradeType.Specific || poke.Type == PokeTradeType.Clone || poke.Type == PokeTradeType.FixOT || poke.Type == PokeTradeType.PowerUp || poke.Type == PokeTradeType.EggRoll)
                         DumpPokemon(DumpSetting.DumpFolder, "traded", pkm); // sent to partner
                 }
             }

--- a/SysBot.Pokemon/BotTrade/PokeTradeType.cs
+++ b/SysBot.Pokemon/BotTrade/PokeTradeType.cs
@@ -7,6 +7,7 @@
         Seed,
         Clone,
         FixOT,
+        PowerUp,
         EggRoll,
         Dump,
     }

--- a/SysBot.Pokemon/Queues/TradeQueueManager.cs
+++ b/SysBot.Pokemon/Queues/TradeQueueManager.cs
@@ -12,6 +12,7 @@ namespace SysBot.Pokemon
         private readonly PokeTradeQueue<T> Seed = new PokeTradeQueue<T>(PokeTradeType.Seed);
         private readonly PokeTradeQueue<T> Clone = new PokeTradeQueue<T>(PokeTradeType.Clone);
         private readonly PokeTradeQueue<T> FixOT = new PokeTradeQueue<T>(PokeTradeType.FixOT);
+        private readonly PokeTradeQueue<T> PowerUp = new PokeTradeQueue<T>(PokeTradeType.PowerUp);
         private readonly PokeTradeQueue<T> EggRoll = new PokeTradeQueue<T>(PokeTradeType.EggRoll);
         private readonly PokeTradeQueue<T> Dump = new PokeTradeQueue<T>(PokeTradeType.Dump);
         public readonly TradeQueueInfo<T> Info;
@@ -21,7 +22,7 @@ namespace SysBot.Pokemon
         {
             Hub = hub;
             Info = new TradeQueueInfo<T>(hub);
-            AllQueues = new[] { Seed, Dump, Clone, FixOT, EggRoll, Trade, };
+            AllQueues = new[] { Seed, Dump, Clone, FixOT, PowerUp, EggRoll, Trade, };
 
             foreach (var q in AllQueues)
                 q.Queue.Settings = hub.Config.Favoritism;
@@ -34,6 +35,7 @@ namespace SysBot.Pokemon
                 PokeRoutineType.SeedCheck => Seed,
                 PokeRoutineType.Clone => Clone,
                 PokeRoutineType.FixOT => FixOT,
+                PokeRoutineType.PowerUp => PowerUp,
                 PokeRoutineType.EggRoll => EggRoll,
                 PokeRoutineType.Dump => Dump,
                 _ => Trade,
@@ -130,6 +132,8 @@ namespace SysBot.Pokemon
             if (TryDequeueInternal(PokeRoutineType.Clone, out detail, out priority))
                 return true;
             if (TryDequeueInternal(PokeRoutineType.FixOT, out detail, out priority))
+                return true;
+            if (TryDequeueInternal(PokeRoutineType.PowerUp, out detail, out priority))
                 return true;
             if (TryDequeueInternal(PokeRoutineType.EggRoll, out detail, out priority))
                 return true;

--- a/SysBot.Pokemon/Settings/CountSettings.cs
+++ b/SysBot.Pokemon/Settings/CountSettings.cs
@@ -25,6 +25,8 @@ namespace SysBot.Pokemon
 
         [Category(Trades), Description("Completed FixOT Trades (Specific User)")]
         public int CompletedFixOTs { get; set; }
+        [Category(Trades), Description("Completed PowerUp Trades (Specific User)")]
+        public int CompletedPowerUps { get; set; }
 
         [Category(Trades), Description("Completed EggRoll Trades (Specific User)")]
         public int CompletedEggRolls { get; set; }

--- a/SysBot.Pokemon/Settings/DiscordSettings.cs
+++ b/SysBot.Pokemon/Settings/DiscordSettings.cs
@@ -43,6 +43,8 @@ namespace SysBot.Pokemon
 
         [Category(Whitelists), Description("Users with this role are allowed to enter the FixOT queue.")]
         public string RoleCanFixOT { get; set; } = DefaultDisable;
+        [Category(Whitelists), Description("Users with this role are allowed to enter the PowerUp queue.")]
+        public string RoleCanPowerUp { get; set; } = DefaultDisable;
 
         [Category(Whitelists), Description("Users with this role are allowed to enter the EggRoll queue.")]
         public string RoleCanEggRoll { get; set; } = DefaultDisable;

--- a/SysBot.Pokemon/Settings/QueueSettings.cs
+++ b/SysBot.Pokemon/Settings/QueueSettings.cs
@@ -53,6 +53,8 @@ namespace SysBot.Pokemon
 
         [Category(UserBias), Description("Biases the FixOT Queue's weight based on how many users are in the queue.")]
         public int YieldMultCountFixOT { get; set; } = 100;
+        [Category(UserBias), Description("Biases the PowerUp Queue's weight based on how many users are in the queue.")]
+        public int YieldMultCountPowerUp { get; set; } = 100;
 
         [Category(UserBias), Description("Biases the EggRoll Queue's weight based on how many users are in the queue.")]
         public int YieldMultCountEggRoll { get; set; } = 100;
@@ -74,8 +76,10 @@ namespace SysBot.Pokemon
         [Category(TimeBias), Description("Checks time elapsed since the user joined the Clone queue, and increases the queue's weight accordingly.")]
         public int YieldMultWaitClone { get; set; } = 1;
 
-        [Category(TimeBias), Description("Checks time elapsed since the user joined the FitOT queue, and increases the queue's weight accordingly.")]
+        [Category(TimeBias), Description("Checks time elapsed since the user joined the FixOT queue, and increases the queue's weight accordingly.")]
         public int YieldMultWaitFixOT { get; set; } = 1;
+        [Category(TimeBias), Description("Checks time elapsed since the user joined the PowerUp queue, and increases the queue's weight accordingly.")]
+        public int YieldMultWaitPowerUp { get; set; } = 1;
 
         [Category(TimeBias), Description("Checks time elapsed since the user joined the EggRoll queue, and increases the queue's weight accordingly.")]
         public int YieldMultWaitEggRoll { get; set; } = 1;
@@ -93,6 +97,7 @@ namespace SysBot.Pokemon
                 PokeTradeType.Seed => YieldMultCountSeedCheck,
                 PokeTradeType.Clone => YieldMultCountClone,
                 PokeTradeType.FixOT => YieldMultCountFixOT,
+                PokeTradeType.PowerUp => YieldMultCountPowerUp,
                 PokeTradeType.EggRoll => YieldMultCountEggRoll,
                 PokeTradeType.Dump => YieldMultCountDump,
                 _ => YieldMultCountTrade
@@ -106,6 +111,7 @@ namespace SysBot.Pokemon
                 PokeTradeType.Seed => YieldMultWaitSeedCheck,
                 PokeTradeType.Clone => YieldMultWaitClone,
                 PokeTradeType.FixOT => YieldMultWaitFixOT,
+                PokeTradeType.PowerUp => YieldMultWaitPowerUp
                 PokeTradeType.EggRoll => YieldMultWaitEggRoll,
                 PokeTradeType.Dump => YieldMultWaitDump,
                 _ => YieldMultWaitTrade

--- a/SysBot.Pokemon/Structures/PokeBotRunner.cs
+++ b/SysBot.Pokemon/Structures/PokeBotRunner.cs
@@ -99,6 +99,7 @@ namespace SysBot.Pokemon
                 case PokeRoutineType.LinkTrade:
                 case PokeRoutineType.Clone:
                 case PokeRoutineType.FixOT:
+                case PokeRoutineType.PowerUp:
                 case PokeRoutineType.EggRoll:
                 case PokeRoutineType.Dump:
                 case PokeRoutineType.SeedCheck:


### PR DESCRIPTION
Adds PowerUp command to the clone module. Maxes out EXP, dynamax level, and PP ups of a Pokémon you show via Link Trade, teaches all compatible TRs, enables gigantamax if available, and hyper trains all non min/maxed IVs. Behaves most like FixOT, where you present a pokemon, then within the same trade the bot offers back the same pokemon with some changes applied.

The use case here is if you have an existing pokemon you want to make usable in battle rather than generating one from scratch, your options are either blowing a bunch of in game resources, or scanning it with a bot then fiddling around in PKHeX then trading it back to yourself. This has come up enough times that I wanted to automate as much of this process as possible and make a general power up command that quickly does all of the generic things without having to mess around on your computer. 