### PR TITLE
Fix/document LA multispawner tables, update dependencies

### DIFF
--- a/SysBot.Base/SysBot.Base.csproj
+++ b/SysBot.Base/SysBot.Base.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.1.1" />
+    <PackageReference Include="NLog" Version="5.3.4" />
     <PackageReference Include="LibUsbDotNet" Version="2.2.29" />
   </ItemGroup>
 

--- a/SysBot.Pokemon.Discord/Helpers/EtumrepDump/PermuteUtil.cs
+++ b/SysBot.Pokemon.Discord/Helpers/EtumrepDump/PermuteUtil.cs
@@ -12,7 +12,7 @@ using PKHeX.Core;
 
 namespace SysBot.Pokemon.Discord
 {
-    public class PermuteUtil
+    public static class PermuteUtil
     {
         // Thanks to Zyro for his initial implementation of multis!
         // https://github.com/zyro670/NotForkBot.NET/commit/b64bbfc344fbbdaba9982a2b111c116698c830fe
@@ -23,164 +23,164 @@ namespace SysBot.Pokemon.Discord
         {
             FakeSlots = new SlotDetail[][]
             {
-                new SlotDetail[]
+                new SlotDetail[] // Fieldlands: 87F39EBD429BF90C; Not Night; Sunny, Cloudy, Intense Sun, Fog, Rainstorm (2-2)
                 {
-                    new(100, "Bidoof", false, new[] { 3, 6 }, 0),
-                    new(2, "Bidoof", true, new[] { 17, 19 }, 3),
-                    new(20, "Eevee", false, new[] { 3, 6 }, 0),
-                    new(1, "Eevee", true, new[] { 17, 19 }, 3),
+                    new(100, "Bidoof", false, new[] {  3,  6 }, 0),
+                    new(  2, "Bidoof", true,  new[] { 18, 21 }, 3),
+                    new( 20, "Eevee",  false, new[] {  3,  6 }, 0),
+                    new(  1, "Eevee",  true,  new[] { 18, 21 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Mirelands: 0D8EAAF095C52F35, E1ABFA12F052870F; Not Night; All weather (2-2)
                 {
-                    new(100, "Combee", false, new [] {17, 20}, 0),
-                    new(2, "Combee", true , new [] {32, 35}, 3),
+                    new(100, "Combee", false, new[] { 17, 20 }, 0),
+                    new(  2, "Combee", true,  new[] { 32, 35 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Coastlands: 98377DDDC282361F, A6E9A110EBF37C0D, BFDB454F1B881B09, 3B2E318D82A87165; Not Night; All weather (3-3)
                 {
-                    new(100, "Qwilfish", false, new [] {41, 44}, 0),
-                    new(1, "Qwilfish", true , new [] {56, 59}, 3),
+                    new(100, "Qwilfish-1", false, new[] { 41, 44 }, 0),
+                    new(  1, "Qwilfish-1", true,  new[] { 56, 59 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Fieldlands: B829961431D954A4; Not Night; All weather (2-2)
                 {
-                    new(100, "Abra", false, new[] { 12, 15 }, 0),
-                    new(2, "Abra", true, new[] { 27, 30 }, 3),
-                    new(30, "Kadabra", false, new[] { 16, 19 }, 0),
-                    new(1, "Kadabra", true, new[] { 31, 34 }, 3),
+                    new(100, "Abra",    false, new[] { 12, 15 }, 0),
+                    new(  2, "Abra",    true,  new[] { 27, 30 }, 3),
+                    new( 30, "Kadabra", false, new[] { 16, 19 }, 0),
+                    new(  1, "Kadabra", true,  new[] { 31, 34 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Coastlands: D8AB0E11253761F3, 2630CA408C60BE57, 617CED822144D04A; Not Night; All weather (2-2)
                 {
-                    new(100, "Basculin-2", false, new [] {41, 44}, 0),
-                    new(2, "Basculin-2", true , new [] {56, 59}, 3),
+                    new(100, "Basculin-2", false, new[] { 41, 44 }, 0),
+                    new(  1, "Basculin-2", true,  new[] { 56, 59 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Fieldlands: A677C613CF0236A7; All times; Sunny, Cloudy, Fog (2-2)
                 {
-                    new(100, "Magikarp", false, new [] {16, 19}, 0),
-                    new(2, "Magikarp", true , new [] {31, 34}, 3),
-                    new(30, "Gyarados", false, new [] {53, 56}, 0),
-                    new(1, "Gyarados", true , new [] {68, 71}, 3),
+                    new(100, "Magikarp", false, new[] { 16, 19 }, 0),
+                    new(  2, "Magikarp", true,  new[] { 31, 34 }, 3),
+                    new( 30, "Gyarados", false, new[] { 53, 56 }, 0),
+                    new(  1, "Gyarados", true,  new[] { 68, 71 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Fieldlands: 264C1AE897749DE3; All times; All weather (2-2)
                 {
-                    new(100, "Shellos", false, new [] {26, 29}, 0),
-                    new(2, "Shellos", true , new [] {41, 44}, 3),
-                    new(50, "Gastrodon", false, new [] {33, 36}, 0),
-                    new(1, "Gastrodon", true , new [] {48, 51}, 3),
+                    new(100, "Shellos",   false, new[] { 26, 29 }, 0),
+                    new(  2, "Shellos",   true,  new[] { 41, 44 }, 3),
+                    new( 50, "Gastrodon", false, new[] { 33, 36 }, 0),
+                    new(  1, "Gastrodon", true,  new[] { 48, 51 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Mirelands: DFDE7E3B3FFEF5C9; Not Night; Cloudy, Rain, Rainstorm (2-2)
                 {
-                    new(40, "Ralts", false, new [] {19, 22}, 0),
-                    new(1, "Ralts", true , new [] {34, 37}, 3),
-                    new(100, "Budew", false, new [] {19, 22}, 0),
-                    new(2, "Budew", true , new [] {34, 37}, 3),
-                    new(50, "Roselia", false, new [] {19, 22}, 0),
-                    new(1, "Roselia", true , new [] {34, 37}, 3),
+                    new( 40, "Ralts",   false, new[] { 19, 22 }, 0),
+                    new(  1, "Ralts",   true,  new[] { 34, 37 }, 3),
+                    new(100, "Budew",   false, new[] { 19, 22 }, 0),
+                    new(  2, "Budew",   true,  new[] { 34, 37 }, 3),
+                    new( 50, "Roselia", false, new[] { 19, 22 }, 0),
+                    new(  1, "Roselia", true,  new[] { 34, 37 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Mirelands: 3402DE384DC3A82A; Not Night; All weather (2-2)
                 {
-                    new(100, "Hippopotas", false, new [] {21, 24}, 0),
-                    new(2, "Hippopotas", true , new [] {36, 39}, 3),
-                    new(30, "Hippowdon", false, new [] {34, 37}, 0),
-                    new(1, "Hippowdon", true , new [] {49, 52}, 3),
+                    new(100, "Hippopotas", false, new[] { 21, 24 }, 0),
+                    new(  2, "Hippopotas", true,  new[] { 36, 39 }, 3),
+                    new( 30, "Hippowdon",  false, new[] { 34, 37 }, 0),
+                    new(  1, "Hippowdon",  true,  new[] { 49, 52 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Fieldlands: 0E4264E9B8F2E85F; Not Night; All weather (2-2)
                 {
-                    new(100, "Aipom", false, new [] {24, 27}, 0),
-                    new(2, "Aipom", true , new [] {39, 42}, 3),
+                    new(100, "Aipom", false, new[] { 24, 27 }, 0),
+                    new(  2, "Aipom", true,  new[] { 39, 42 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Fieldlands: 7F13E7A756EAECEA; Not Night; All weather (2-2)
                 {
-                    new(20, "Pikachu", false , new [] {9, 12}, 0),
-                    new(1, "Pikachu", true, new [] {24, 27}, 3),
-                    new(10, "Pichu", false, new [] {9, 12}, 0),
-                    new(1, "Pichu", true , new [] {24, 27}, 3),
-                    new(100, "Kricketot", false, new [] {6, 9}, 0),
-                    new(2, "Kricketot", true , new [] {21, 24}, 3),
+                    new( 20, "Pikachu",   false, new[] {  9, 12 }, 0),
+                    new(  1, "Pikachu",   true,  new[] { 24, 27 }, 3),
+                    new( 10, "Pichu",     false, new[] {  9, 12 }, 0),
+                    new(  1, "Pichu",     true,  new[] { 24, 27 }, 3),
+                    new(100, "Kricketot", false, new[] {  6,  9 }, 0),
+                    new(  2, "Kricketot", true,  new[] { 21, 24 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Fieldlands: 371EA9452422392A; All times; Sunny, Cloudy, Fog (2-2)
                 {
-                    new(100, "Psyduck", false, new [] {13, 16}, 0),
-                    new(25, "Psyduck", false, new [] {13, 16}, 0),
-                    new(2, "Psyduck", true, new [] {28, 31}, 3),
-                    new(100, "Buneary", false , new [] {13, 16}, 0),
-                    new(25, "Buneary", false , new [] {13, 16}, 0),
-                    new(2, "Buneary", true , new [] {28, 31}, 3),
+                    new(100, "Psyduck", false, new[] { 13, 16 }, 0),
+                    new( 25, "Psyduck", false, new[] { 13, 16 }, 0),
+                    new(  2, "Psyduck", true,  new[] { 28, 31 }, 3),
+                    new(100, "Buneary", false, new[] { 13, 16 }, 0),
+                    new( 25, "Buneary", false, new[] { 13, 16 }, 0),
+                    new(  2, "Buneary", true,  new[] { 28, 31 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Mirelands: 90B205067060D0BC; Not Night; Not Sunny (3-3)
                 {
-                    new(100, "Petilil", false, new [] {33, 36}, 0),
-                    new(2, "Petilil", true , new [] {48, 51}, 3),
+                    new(100, "Petilil", false, new[] { 33, 36 }, 0),
+                    new(  2, "Petilil", true,  new[] { 48, 51 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Mirelands: 90B205067060D0BC; Night; Not Sunny (3-3)
                 {
-                    new(100, "Petilil", false, new [] {33, 36}, 0),
-                    new(2, "Petilil", true , new [] {48, 51}, 3),
-                    new(50, "Gastly", false , new [] {21, 24}, 0),
-                    new(2, "Gastly", true, new [] {36, 39}, 3),
-                    new(30, "Haunter", false, new [] {33, 36}, 0),
-                    new(1, "Haunter", true , new [] {48, 51}, 3),
+                    new(100, "Petilil", false, new[] { 33, 36 }, 0),
+                    new(  2, "Petilil", true,  new[] { 48, 51 }, 3),
+                    new( 50, "Gastly",  false, new[] { 21, 24 }, 0),
+                    new(  2, "Gastly",  true,  new[] { 36, 39 }, 3),
+                    new( 30, "Haunter", false, new[] { 33, 36 }, 0),
+                    new(  1, "Haunter", true,  new[] { 48, 51 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Coastlands: 3BC31AA6F5337A4D; All times; All weather (2-2)
                 {
-                    new(100, "Glameow", false, new [] {34, 37}, 0),
-                    new(1, "Glameow", true, new [] {49, 52}, 3),
-                    new(40, "Purugly", false , new [] {41, 44}, 0),
-                    new(1, "Purugly", true , new [] {56, 59}, 3),
+                    new(100, "Glameow", false, new[] { 34, 37 }, 0),
+                    new(  1, "Glameow", true,  new[] { 49, 52 }, 3),
+                    new( 40, "Purugly", false, new[] { 41, 44 }, 0),
+                    new(  1, "Purugly", true,  new[] { 56, 59 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Mirelands: 8A628649D2AB899C; All times; All weather (2-2)
                 {
-                    new(30, "Teddiursa", false , new [] {26, 29}, 0),
-                    new(2, "Teddiursa", true, new [] {41, 44}, 3),
-                    new(100, "Ursaring", false, new [] {37, 40}, 0),
-                    new(1, "Ursaring", true , new [] {52, 55}, 3),
+                    new( 30, "Teddiursa", false, new[] { 26, 29 }, 0),
+                    new(  2, "Teddiursa", true,  new[] { 41, 44 }, 3),
+                    new(100, "Ursaring",  false, new[] { 37, 40 }, 0),
+                    new(  1, "Ursaring",  true,  new[] { 52, 55 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Fieldlands: A366202BD3643B7E; Not Night; All weather (2-2)
                 {
-                    new(100, "Beautifly", false, new [] {15, 18}, 0),
-                    new(1, "Beautifly", true, new [] {30, 33}, 3),
-                    new(100, "Mothim", false , new [] {20, 23}, 0),
-                    new(1, "Mothim", true , new [] {35, 38}, 3),
+                    new(100, "Beautifly", false, new[] { 15, 18 }, 0),
+                    new(  1, "Beautifly", true,  new[] { 30, 33 }, 3),
+                    new(100, "Mothim",    false, new[] { 20, 23 }, 0),
+                    new(  1, "Mothim",    true,  new[] { 35, 38 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Fieldlands: A366202BD3643B7E; Night; All weather (2-2)
                 {
-                    new(100, "Dustox", false, new [] {15, 18}, 0),
-                    new(1, "Dustox", true, new [] {30, 33}, 3),
-                    new(100, "Mothim", false , new [] {20, 23}, 0),
-                    new(1, "Mothim", true , new [] {35, 38}, 3),
+                    new(100, "Dustox", false, new[] { 15, 18 }, 0),
+                    new(  1, "Dustox", true,  new[] { 30, 33 }, 3),
+                    new(100, "Mothim", false, new[] { 20, 23 }, 0),
+                    new(  1, "Mothim", true,  new[] { 35, 38 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Coastlands: 1FB2A7A1C1FBFEBD; Night; All weather (2-2)
                 {
-                    new(100, "Murkrow", false, new [] {31, 34}, 0),
-                    new(2, "Murkrow", true , new [] {46, 49}, 3),
+                    new(100, "Murkrow", false, new[] { 31, 34 }, 0),
+                    new(  2, "Murkrow", true,  new[] { 46, 49 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Icelands: 81AB7DC29C2E5AB3; Not Night; Sunny, Cloudy (2-2)
                 {
-                    new(100, "Swinub", false, new [] {29, 32}, 0),
-                    new(2, "Swinub", true , new [] {44, 47}, 3),
-                    new(50, "Piloswine", false, new [] {47, 50}, 0),
-                    new(1, "Piloswine", true , new [] {62, 65}, 3),
+                    new(100, "Swinub",    false, new[] { 29, 32 }, 0),
+                    new(  2, "Swinub",    true,  new[] { 44, 47 }, 3),
+                    new( 50, "Piloswine", false, new[] { 47, 50 }, 0),
+                    new(  1, "Piloswine", true,  new[] { 62, 65 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Mirelands: A3C27A3A01165FE6; Not Night; Cloudy, Rain, Fog, Rainstorm (2-2)
                 {
-                    new(100, "Paras", false, new [] {20, 23}, 0),
-                    new(2, "Paras", true , new [] {35, 38}, 3),
-                    new(50, "Parasect", false, new [] {25, 28}, 0),
-                    new(1, "Parasect", true , new [] {40, 43}, 3),
+                    new(100, "Paras",    false, new[] { 20, 23 }, 0),
+                    new(  2, "Paras",    true,  new[] { 35, 38 }, 3),
+                    new( 50, "Parasect", false, new[] { 25, 28 }, 0),
+                    new(  1, "Parasect", true,  new[] { 40, 43 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Mirelands: A3C27A3A01165FE6; Night; Cloudy, Rain, Fog, Rainstorm (2-2)
                 {
-                    new(100, "Paras", false, new [] {20, 23}, 0),
-                    new(2, "Paras", true , new [] {35, 38}, 3),
-                    new(50, "Parasect", false, new [] {25, 28}, 0),
-                    new(1, "Parasect", true , new [] {40, 43}, 3),
-                    new(70, "Zubat", false, new [] {18, 21}, 0),
-                    new(2, "Zubat", true , new [] {33, 36}, 3),
-                    new(30, "Golbat", false, new [] {25, 28}, 0),
-                    new(1, "Golbat", true , new [] {40, 43}, 3),
+                    new(100, "Paras",    false, new[] { 20, 23 }, 0),
+                    new(  2, "Paras",    true,  new[] { 35, 38 }, 3),
+                    new( 50, "Parasect", false, new[] { 25, 28 }, 0),
+                    new(  1, "Parasect", true,  new[] { 40, 43 }, 3),
+                    new( 70, "Zubat",    false, new[] { 18, 21 }, 0),
+                    new(  2, "Zubat",    true,  new[] { 33, 36 }, 3),
+                    new( 30, "Golbat",   false, new[] { 25, 28 }, 0),
+                    new(  1, "Golbat",   true,  new[] { 40, 43 }, 3),
                 },
-                new SlotDetail[]
+                new SlotDetail[] // Icelands: F4A47B912D22A05A, F91217341C696F1F; All times; All weather (2-2)
                 {
-                    new(100, "Rufflet", false, new [] {55, 58}, 0),
-                    new(2, "Rufflet", true , new [] {70, 73}, 3),
+                    new(100, "Rufflet", false, new[] { 55, 58 }, 0),
+                    new(  1, "Rufflet", true,  new[] { 70, 73 }, 3),
                 },
             };
 
@@ -227,7 +227,7 @@ namespace SysBot.Pokemon.Discord
                 {
                     Color = Color.Gold,
                     Description = $"{(service is "multi" && spawnerVal is "" ? "Please select a spawner you would like to permute!" : "Please select your shiny path filter for PermuteMMO!")}",
-                }.WithAuthor(x => { x.Name = "PermuteMMO Service"; }).Build();
+                }.WithAuthor(x => x.Name = "PermuteMMO Service").Build();
 
                 await component.Message.ModifyAsync(x => { x.Embed = embed; x.Components = menu; }).ConfigureAwait(false);
             }
@@ -281,7 +281,7 @@ namespace SysBot.Pokemon.Discord
             {
                 msg += "Invalid JSON format.";
                 LogUtil.LogInfo($"{name}: {msg}", "[PermuteMMO]");
-                await ModalEmbedFollowupAsync(modal, msg, Color.Red);
+                await ModalEmbedFollowupAsync(modal, msg, Color.Red).ConfigureAwait(false);
                 return;
             }
 
@@ -290,7 +290,7 @@ namespace SysBot.Pokemon.Discord
             {
                 msg += "Incorrect second wave spawn count specified, or no second wave provided with a non-zero second wave count.";
                 LogUtil.LogInfo($"{name}: {msg}", "[PermuteMMO]");
-                await ModalEmbedFollowupAsync(modal, msg, Color.Red);
+                await ModalEmbedFollowupAsync(modal, msg, Color.Red).ConfigureAwait(false);
                 return;
             }
 
@@ -299,7 +299,7 @@ namespace SysBot.Pokemon.Discord
             {
                 msg += "Incorrect first wave count specified.";
                 LogUtil.LogInfo($"{name}: {msg}", "[PermuteMMO]");
-                await ModalEmbedFollowupAsync(modal, msg, Color.Red);
+                await ModalEmbedFollowupAsync(modal, msg, Color.Red).ConfigureAwait(false);
                 return;
             }
 
@@ -320,7 +320,7 @@ namespace SysBot.Pokemon.Discord
             {
                 msg += "Invalid seed.";
                 LogUtil.LogInfo($"{name}: {msg}", "[PermuteMMO]");
-                await ModalEmbedFollowupAsync(modal, msg, Color.Red);
+                await ModalEmbedFollowupAsync(modal, msg, Color.Red).ConfigureAwait(false);
                 return;
             }
 
@@ -329,14 +329,14 @@ namespace SysBot.Pokemon.Discord
             {
                 msg += "Invalid advances.";
                 LogUtil.LogInfo($"{name}: {msg}", "[PermuteMMO]");
-                await ModalEmbedFollowupAsync(modal, msg, Color.Red);
+                await ModalEmbedFollowupAsync(modal, msg, Color.Red).ConfigureAwait(false);
                 return;
             }
 
             advances = advances == 0 ? 1 : advances > 20 ? 20 : advances;
             var filter = modal.Data.CustomId.Split(';')[3];
             var info = new UserEnteredSpawnInfo { Seed = seedInput, };
-            await DoPermutationsAsync(modal, info, filter, name, "multi", advances);
+            await DoPermutationsAsync(modal, info, filter, name, "multi", advances).ConfigureAwait(false);
         }
 
         public static async Task HandlePermuteButtonAsync(SocketMessageComponent component, string service)
@@ -425,7 +425,7 @@ namespace SysBot.Pokemon.Discord
             {
                 msg += "Failed to calculate shiny paths due to an unexpected error: is the provided info filled out with valid parameters?";
                 LogUtil.LogInfo($"{name}: {msg}", "[PermuteMMO]");
-                await ModalEmbedFollowupAsync(modal, msg, Color.Red);
+                await ModalEmbedFollowupAsync(modal, msg, Color.Red).ConfigureAwait(false);
                 return;
             }
 

--- a/SysBot.Pokemon.Discord/Helpers/EtumrepDump/PermuteUtil.cs
+++ b/SysBot.Pokemon.Discord/Helpers/EtumrepDump/PermuteUtil.cs
@@ -126,7 +126,7 @@ namespace SysBot.Pokemon.Discord
                     new( 40, "Purugly", false, new[] { 41, 44 }, 0),
                     new(  1, "Purugly", true,  new[] { 56, 59 }, 3),
                 },
-                new SlotDetail[] // Mirelands: 8A628649D2AB899C; All times; All weather (2-2)
+                new SlotDetail[] // Highlands: 8A628649D2AB899C; All times; All weather (2-2)
                 {
                     new( 30, "Teddiursa", false, new[] { 26, 29 }, 0),
                     new(  2, "Teddiursa", true,  new[] { 41, 44 }, 3),

--- a/SysBot.Pokemon.Discord/SysBot.Pokemon.Discord.csproj
+++ b/SysBot.Pokemon.Discord/SysBot.Pokemon.Discord.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="3.9.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Discord.Net" Version="3.17.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
     <PackageReference Include="PKHeX.Core" Version="23.5.11" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.1" />
     <ProjectReference Include="..\SysBot.Base\SysBot.Base.csproj" />
     <ProjectReference Include="..\SysBot.Pokemon\SysBot.Pokemon.csproj" />
   </ItemGroup>

--- a/SysBot.Pokemon.WinForms/SysBot.Pokemon.WinForms.csproj
+++ b/SysBot.Pokemon.WinForms/SysBot.Pokemon.WinForms.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="PKHeX.Core" Version="23.5.11" />
-    <PackageReference Include="System.Resources.Extensions" Version="7.0.0" />
+    <PackageReference Include="System.Resources.Extensions" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SysBot.Pokemon.YouTube/SysBot.Pokemon.YouTube.csproj
+++ b/SysBot.Pokemon.YouTube/SysBot.Pokemon.YouTube.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis" Version="1.59.0" />
-    <PackageReference Include="Google.Apis.Auth" Version="1.59.0" />
-    <PackageReference Include="Google.Apis.Core" Version="1.59.0" />
-    <PackageReference Include="Google.Apis.YouTube.v3" Version="1.58.0.2874" />
+    <PackageReference Include="Google.Apis" Version="1.69.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
+    <PackageReference Include="Google.Apis.Core" Version="1.69.0" />
+    <PackageReference Include="Google.Apis.YouTube.v3" Version="1.69.0.3674" />
     <PackageReference Include="Google.Apis.YouTubePartner.v1" Version="1.35.1.1334" />
     <PackageReference Include="PKHeX.Core" Version="23.5.11" />
   </ItemGroup>

--- a/SysBot.Pokemon.Z3/SysBot.Pokemon.Z3.csproj
+++ b/SysBot.Pokemon.Z3/SysBot.Pokemon.Z3.csproj
@@ -16,7 +16,7 @@
     <When Condition=" '$(Platform)' == 'x64' OR $(RuntimeIdentifier.EndsWith('x64')) ">
       <!-- x64 specific references -->
       <ItemGroup>
-        <PackageReference Include="Microsoft.Z3" Version="4.12.0" />
+        <PackageReference Include="Microsoft.Z3" Version="4.12.2" />
       </ItemGroup>
     </When>
     

--- a/SysBot.Pokemon/SysBot.Pokemon.csproj
+++ b/SysBot.Pokemon/SysBot.Pokemon.csproj
@@ -15,10 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PKHeX.Core" Version="23.5.11" />
     <PackageReference Include="KdSoft.FlatBuffers" Version="1.12.0" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.114.4" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.119" />
     <ProjectReference Include="..\SysBot.Base\SysBot.Base.csproj" />
   </ItemGroup>
 

--- a/SysBot.Tests/PokePoolTests.cs
+++ b/SysBot.Tests/PokePoolTests.cs
@@ -19,7 +19,7 @@ namespace SysBot.Tests
             pool.Add(a);
             pool.Add(b);
 
-            pool.Count.Should().BeGreaterOrEqualTo(2);
+            pool.Count.Should().BeGreaterThanOrEqualTo(2);
 
             while (true) { if (ReferenceEquals(pool.GetRandomPoke(), a)) break; }
             while (true) { if (ReferenceEquals(pool.GetRandomPoke(), b)) break; }

--- a/SysBot.Tests/SysBot.Tests.csproj
+++ b/SysBot.Tests/SysBot.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="FluentAssertions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Some of the LA multispawner tables were off, which was causing bad results. I added additional comments with the spawner hash and what time/weather they are active. That way, guide writers can also direct users to the correct encounter conditions.

This updates dependencies that were vulnerable as well, and adds some missing `ConfigureAwait(false)`.

Here's the encounter dump (in order, by weight) that this is based on. I'd like at least another set of eyes comparing the tables with this dump before merging to eliminate entry errors.

[Encounters_All.txt](https://github.com/user-attachments/files/18583952/Encounters_All.txt)